### PR TITLE
Array argument support

### DIFF
--- a/capdpa/IR/ir_array.py
+++ b/capdpa/IR/ir_array.py
@@ -1,6 +1,7 @@
 
 import ir
 import ir_template
+import mangle
 
 class Array(ir.Base):
 
@@ -14,6 +15,10 @@ class Array(ir.Base):
     def UsedTypes(self, parent):
         return self.ctype.UsedTypes(parent)
 
+    def Mangle(self):
+        return mangle.Pointer(self.ctype.Mangle())
+
     def AdaSpecification(self, indentation=0, private=False):
-        return self.ctype.AdaSpecification(indentation, private) + "_Array (1 .. {})".format(self.size)
+        return self.ctype.AdaSpecification(indentation, private) + "_Array" + (
+                " (1 .. {})".format(self.size) if self.size != None else "")
 

--- a/capdpa/cxx.py
+++ b/capdpa/cxx.py
@@ -262,6 +262,10 @@ class CXX:
             return IR.Array(
                     ctype = self.__convert_type(children, type_cursor.element_type),
                     size = IR.Template_Argument(name = children[0].spelling))
+        elif type_cursor.kind == clang.cindex.TypeKind.INCOMPLETEARRAY:
+            return IR.Array(
+                    ctype = self.__convert_type(children, type_cursor.element_type),
+                    size = None);
         elif type_cursor.kind in TypeMap.keys():
             return IR.Type_Reference(
                 name = IR.Identifier([self.project, TypeMap[type_cursor.kind]]),

--- a/tests/data/convert/test_array_parameter.h
+++ b/tests/data/convert/test_array_parameter.h
@@ -1,0 +1,6 @@
+
+class A
+{
+    public:
+        A(int x[]);
+};

--- a/tests/data/generator/test_array_parameter.txt
+++ b/tests/data/generator/test_array_parameter.txt
@@ -1,0 +1,28 @@
+package Capdpa
+   with SPARK_Mode => On
+is
+   package A
+      with SPARK_Mode => On
+   is
+      type Class is
+      limited record
+         null;
+      end record
+      with Import, Convention => CPP;
+
+      type Class_Address is private;
+      type Class_Array is array (Natural range <>) of Class;
+      type Class_Address_Array is array (Natural range <>) of Class_Address;
+
+      function Constructor (X : Capdpa.Int_Array) return Class
+      with Global => null;
+      pragma Cpp_Constructor (Constructor, "_ZN1AC1EPi");
+
+   private
+      pragma SPARK_Mode (Off);
+
+      type Class_Address is access Class;
+
+   end A;
+
+end Capdpa;

--- a/tests/data/test_array_parameter/impl.cpp
+++ b/tests/data/test_array_parameter/impl.cpp
@@ -1,0 +1,13 @@
+
+#include "impl.h"
+
+Cls::Cls() { }
+
+int Cls::sum(int list[], int length)
+{
+    int s = 0;
+    for(int i = 0; i < length; i++){
+        s += list[i];
+    }
+    return s;
+}

--- a/tests/data/test_array_parameter/impl.h
+++ b/tests/data/test_array_parameter/impl.h
@@ -1,0 +1,7 @@
+
+class Cls
+{
+    public:
+        Cls();
+        int sum(int list[], int length);
+};

--- a/tests/data/test_array_parameter/main.adb
+++ b/tests/data/test_array_parameter/main.adb
@@ -1,0 +1,13 @@
+with Tests;
+with Test_Array_Parameter;
+
+procedure Main
+   with SPARK_Mode => Off
+is
+   List : Test_Array_Parameter.Int_Array (1 .. 10) := (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+   C : aliased Test_Array_Parameter.Cls.Class := Test_Array_Parameter.Cls.Constructor;
+   Sum : Integer;
+begin
+   Sum := Integer (Test_Array_Parameter.Cls.Sum (C, List, Test_Array_Parameter.Int (List'Length)));
+   Tests.Assert (Sum = 55, "Wrong sum returned: " & Sum'Img);
+end Main;

--- a/tests/data/test_mangling.h
+++ b/tests/data/test_mangling.h
@@ -81,6 +81,10 @@ class Main
       void method_builtin_float (float) { };
       void method_builtin_double (double) { };
       void method_builtin_long_double (long double) { };
+
+      void method_with_constrained_array(int [42]);
+      void method_with_unconstrained_array(int []);
+      void method_with_null_array(int [0]);
 };
 
 namespace std {

--- a/tests/testconvert.py
+++ b/tests/testconvert.py
@@ -372,6 +372,16 @@ class Parser(Capdpa_Test):
         result = CXX("tests/data/convert/test_class_with_array.h").ToIR(project="Capdpa")
         self.check(result, expected)
 
+    def test_array_parameter(self):
+        expected = Namespace(name = "Capdpa", children = [
+            Class(name = "A", children = [
+                Constructor (parameters = [
+                    Argument(name = "x", ctype = Array(
+                        ctype = Type_Reference(name = Identifier(["Capdpa", "int"])),
+                        size = None))])])])
+        result = CXX("tests/data/convert/test_array_parameter.h").ToIR(project="Capdpa")
+        self.check(result, expected)
+
     def test_array_template(self):
         expected = Namespace(name = "Capdpa", children = [
             Template(entity=

--- a/tests/testgenerator.py
+++ b/tests/testgenerator.py
@@ -358,6 +358,15 @@ class GenerateConstant(Capdpa_Test):
                 Member(name = "ar", ctype = Array(ctype = Type_Reference(name = Identifier(["Capdpa", "Int"])), size=5))])]).AdaSpecification()
         self.check(result[0].Text(), self.load("generator/test_class_with_array.txt"))
 
+    def test_array_parameter(self):
+        result = Namespace(name = "Capdpa", children = [
+            Class(name = "A", children = [
+                Constructor(parameters = [
+                    Argument(name = "x", ctype = Array(
+                        ctype = Type_Reference(name = Identifier(["Capdpa", "int"])),
+                        size = None))])])]).AdaSpecification()
+        self.check(result[0].Text(), self.load("generator/test_array_parameter.txt"))
+
     def test_template_with_array(self):
         result = Namespace(name = "Capdpa", children = [
             Template(entity=

--- a/tests/testmangling.py
+++ b/tests/testmangling.py
@@ -357,6 +357,14 @@ class Mangling(unittest.TestCase):
         symbol = str(self.tests['Literal_Template_T_Int_17'].children[1].Mangle())
         self.assertTrue (symbol == "_ZN16Literal_TemplateILi17EEC1Ev", "Invalid symbol: " + symbol)
 
+    def test_array(self):
+        symbol = str(self.tests['Main', 'method_with_constrained_array'].Mangle())
+        self.assertTrue (symbol == "_ZN4Main29method_with_constrained_arrayEPi", "Invalid symbol: " + symbol)
+        symbol = str(self.tests['Main', 'method_with_unconstrained_array'].Mangle())
+        self.assertTrue (symbol == "_ZN4Main31method_with_unconstrained_arrayEPi", "Invalid symbol: " + symbol)
+        symbol = str(self.tests['Main', 'method_with_null_array'].Mangle())
+        self.assertTrue (symbol == "_ZN4Main22method_with_null_arrayEPi", "Invalid symbol: " + symbol)
+
     def EXCLUDE_test_template_instance_complex (self):
         symbol = str(self.tests['Templ2', ['Cde_T_Char_Int', 'foo']].Mangle())
         self.assertTrue (symbol == "_ZN6Templ23CdeIcN3Bar3FooEE3fooEcS3_i", "Invalid symbol: " + symbol)

--- a/tests/testvalidation.py
+++ b/tests/testvalidation.py
@@ -177,6 +177,9 @@ class check_validation(Capdpa_Test):
     def test_dependent_arrays(self):
         self.check_validation("test_dependent_arrays")
 
+    def test_array_parameter(self):
+        self.check_validation("test_array_parameter")
+
     def test_nested_private_class(self):
         self.check_validation("test_nested_private_class")
 


### PR DESCRIPTION
Support for array arguments such as `void func(int []);`. While the Titanium ABI proposes different manglings for array parameters GCC and Clang only mangle them as pointers. So `void func(int [])`, `void func(int*)` and `void func(int [42])` all produce the same symbol (`_Z4funcPi`).